### PR TITLE
Update outdated dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,6 @@
         "codeclimate/php-test-reporter": "^0.4.4",
         "phpstan/phpstan": "^0.12.14",
         "phpstan/phpstan-phpunit": "^0.12.6",
-        "jangregor/phpstan-prophecy": "^0.6.2",
         "phpstan/phpstan-strict-rules": "^0.12.2",
         "codeception/verify": "^1.3",
         "php-http/mock-client": "^1.3",
@@ -50,7 +49,8 @@
         "php-http/curl-client": "^2.1",
         "kriswallsmith/buzz": "^1.1",
         "php-http/vcr-plugin": "^1.0",
-        "laminas/laminas-diactoros": "^2.2"
+        "laminas/laminas-diactoros": "^2.2",
+        "jangregor/phpstan-prophecy": "^0.8.0"
     },
     "scripts": {
         "phpunit": "phpunit --coverage-text"

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -6,5 +6,5 @@ parameters:
 includes:
     - vendor/phpstan/phpstan-phpunit/extension.neon
     - vendor/phpstan/phpstan-phpunit/rules.neon
-    - vendor/jangregor/phpstan-prophecy/src/extension.neon
+    - vendor/jangregor/phpstan-prophecy/extension.neon
     - vendor/phpstan/phpstan-strict-rules/rules.neon

--- a/tests/GetGiveawayListTest.php
+++ b/tests/GetGiveawayListTest.php
@@ -37,7 +37,7 @@ class GetGiveawayListTest extends TestCase
      * @param Client $client
      * @dataProvider httpClientExamples
      */
-    public function testGetGiveawayList(Client $client)
+    public function testGetGiveawayList(Client $client): void
     {
         $userList = $client->getGiveawayList(['9KfZs', '9KfKs']);
         expect($userList)->isInstanceOf(GiveawayList::class);


### PR DESCRIPTION
### What is done?
Updated outdated the `jangregor/phpstan-prophecy` composer dependency from `0.6.2` to `0.8.0` version.