### PR TITLE
Add user lazy loading via proxy

### DIFF
--- a/src/Application/GiveawayProvider/HttpGiveawayProcessor/CreatorProcessor.php
+++ b/src/Application/GiveawayProvider/HttpGiveawayProcessor/CreatorProcessor.php
@@ -4,6 +4,7 @@
 namespace Marmozist\SteamGifts\Application\GiveawayProvider\HttpGiveawayProcessor;
 
 
+use Marmozist\SteamGifts\Application\Proxy\LazyUserProxy;
 use Marmozist\SteamGifts\Application\Utils\XPathTrait;
 use Marmozist\SteamGifts\Component\Giveaway\GiveawayBuilder;
 use Marmozist\SteamGifts\UseCase\GetUser;
@@ -31,11 +32,7 @@ class CreatorProcessor implements GiveawayProcessor
 
         if ($this->hasNode($expression)) {
             $username = $this->getNodeText($expression);
-            $user = $this->interactor->getUser($username);
-            if ($user === null) {
-                return;
-            }
-
+            $user = new LazyUserProxy($this->interactor, $username);
             $builder->setCreator($user);
         }
     }

--- a/src/Application/Proxy/LazyUserProxy.php
+++ b/src/Application/Proxy/LazyUserProxy.php
@@ -1,0 +1,129 @@
+<?php declare(strict_types=1);
+
+
+namespace Marmozist\SteamGifts\Application\Proxy;
+
+
+use Marmozist\SteamGifts\Component\User\User;
+use Marmozist\SteamGifts\Component\User\UserRole;
+use Marmozist\SteamGifts\UseCase\GetUser;
+use DateTimeImmutable;
+
+/**
+ * @link    http://github.com/marmozist/steam-gifts
+ * @license http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
+ * @author  Andrey Gotmanov <gotman.man@gmail.com>
+ */
+class LazyUserProxy extends User
+{
+    private GetUser\Interactor $interactor;
+    private string $username;
+    private bool $loaded = false;
+
+    public function __construct(GetUser\Interactor $interactor, string $username)
+    {
+        $this->interactor = $interactor;
+        $this->username = $username;
+
+        $date = (new DateTimeImmutable())->setTimestamp(0);
+        parent::__construct($username, UserRole::None(), $date, $date, '', '', 0, 0, 0, 0, 0);
+    }
+
+    public function getRole(): UserRole
+    {
+        $this->loadUser();
+
+        return parent::getRole();
+    }
+
+    public function getLastOnlineAt(): DateTimeImmutable
+    {
+        $this->loadUser();
+
+        return parent::getLastOnlineAt();
+    }
+
+    public function getRegisteredAt(): DateTimeImmutable
+    {
+        $this->loadUser();
+
+        return parent::getRegisteredAt();
+    }
+
+    public function getAvatarUrl(): string
+    {
+        $this->loadUser();
+
+        return parent::getAvatarUrl();
+    }
+
+    public function getSteamLink(): string
+    {
+        $this->loadUser();
+
+        return parent::getSteamLink();
+    }
+
+    public function getComments(): int
+    {
+        $this->loadUser();
+
+        return parent::getComments();
+    }
+
+    public function getEnteredGiveaways(): int
+    {
+        $this->loadUser();
+
+        return parent::getEnteredGiveaways();
+    }
+
+    public function getGiftsWon(): int
+    {
+        $this->loadUser();
+
+        return parent::getGiftsWon();
+    }
+
+    public function getGiftsSent(): int
+    {
+        $this->loadUser();
+
+        return parent::getGiftsSent();
+    }
+
+    public function getContributorLevel(): float
+    {
+        $this->loadUser();
+
+        return parent::getContributorLevel();
+    }
+
+    private function loadUser(): void
+    {
+        if ($this->loaded) {
+            return;
+        }
+
+        /*** @var User $user */
+        $user = $this->interactor->getUser($this->username);
+        if ($user === null) {
+            throw new \InvalidArgumentException(sprintf('User \'%s\' not exists', $this->username));
+        }
+
+        $this->loaded = true;
+        parent::__construct(
+            $user->getName(),
+            $user->getRole(),
+            $user->getRegisteredAt(),
+            $user->getLastOnlineAt(),
+            $user->getAvatarUrl(),
+            $user->getSteamLink(),
+            $user->getComments(),
+            $user->getEnteredGiveaways(),
+            $user->getGiftsWon(),
+            $user->getGiftsSent(),
+            $user->getContributorLevel()
+        );
+    }
+}

--- a/tests/Application/Proxy/LazyUserProxyTest.php
+++ b/tests/Application/Proxy/LazyUserProxyTest.php
@@ -1,0 +1,76 @@
+<?php declare(strict_types=1);
+
+
+namespace Marmozist\Tests\SteamGifts\Application\Proxy;
+
+
+use Marmozist\SteamGifts\Application\Proxy\LazyUserProxy;
+use Marmozist\SteamGifts\Component\User\User;
+use Marmozist\SteamGifts\Component\User\UserRole;
+use Marmozist\SteamGifts\UseCase\GetUser\Interactor;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @link    http://github.com/marmozist/steam-gifts
+ * @license http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
+ * @author  Andrey Gotmanov <gotman.man@gmail.com>
+ */
+class LazyUserProxyTest extends TestCase
+{
+    public function testLazyUserProxy(): void
+    {
+        $username = 'Gotman';
+        $interactor = $this->prophesize(Interactor::class);
+        $interactor->getUser($username)
+            ->shouldBeCalled()
+            ->willReturn(User::createBuilder($username)
+                ->setRole(UserRole::Member())
+                ->setEnteredGiveaways(102)
+                ->build());
+
+        $proxy = new LazyUserProxy($interactor->reveal(), $username);
+        expect($proxy)->isInstanceOf(User::class);
+        expect($proxy->getName())->same($username);
+        expect($proxy->getRole())->equals(UserRole::Member());
+        expect($proxy->getLastOnlineAt())->equals(new \DateTimeImmutable('1970-01-01T00:00:00.000000+0000'));
+        expect($proxy->getRegisteredAt())->equals(new \DateTimeImmutable('1970-01-01T00:00:00.000000+0000'));
+        expect($proxy->getAvatarUrl())->same('');
+        expect($proxy->getSteamLink())->same('');
+        expect($proxy->getComments())->same(0);
+        expect($proxy->getEnteredGiveaways())->same(102);
+        expect($proxy->getGiftsWon())->same(0);
+        expect($proxy->getGiftsSent())->same(0);
+        expect($proxy->getContributorLevel())->same(0.0);
+    }
+
+    public function testLazyUserProxyWithoudCallingMethods(): void
+    {
+        $username = 'Gotman';
+        $interactor = $this->prophesize(Interactor::class);
+        $interactor->getUser($username)
+            ->shouldNotBeCalled();
+
+        $proxy = new LazyUserProxy($interactor->reveal(), $username);
+        expect($proxy)->isInstanceOf(User::class);
+        expect($proxy->getName())->same($username);
+    }
+
+    /**
+     * @test
+     */
+    public function throwsWhenUserNotExists(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('User \'Gotman\' not exists');
+
+        $username = 'Gotman';
+        $interactor = $this->prophesize(Interactor::class);
+        $interactor->getUser($username)
+            ->shouldBeCalled()
+            ->willReturn(null);
+
+        $proxy = new LazyUserProxy($interactor->reveal(), $username);
+        expect($proxy)->isInstanceOf(User::class);
+        $proxy->getRole();
+    }
+}

--- a/tests/GetGiveawayListTest.php
+++ b/tests/GetGiveawayListTest.php
@@ -15,6 +15,7 @@ use Marmozist\SteamGifts\Application\Client;
 use Marmozist\SteamGifts\Application\ClientFactory;
 use Marmozist\SteamGifts\Application\GiveawayProvider\HttpGiveawayProcessor\Factory\CompositeGiveawayProcessorFactory;
 use Marmozist\SteamGifts\Application\GiveawayProvider\HttpGiveawayProvider;
+use Marmozist\SteamGifts\Application\Proxy\LazyUserProxy;
 use Marmozist\SteamGifts\Application\UserProvider\InMemoryUserProvider;
 use Marmozist\SteamGifts\Component\Giveaway\Giveaway;
 use Marmozist\SteamGifts\UseCase\GetGiveawayList\GiveawayList;
@@ -54,7 +55,7 @@ class GetGiveawayListTest extends TestCase
         expect($giveaway->getFinishedAt())->equals(new \DateTimeImmutable('2017-06-27T20:00:00.000000+0000'));
         expect($giveaway->getCreatedAt())->equals(new \DateTimeImmutable('2017-06-26T19:13:12.000000+0000'));
         expect($giveaway->getEntries())->same(911);
-        expect($giveaway->getCreator())->equals($client->getUser('Gotman'));
+        expect($giveaway->getCreator())->equals(new LazyUserProxy(new Interactor(new InMemoryUserProvider()), 'Gotman'));
         expect($giveaway->getCost())->same(2);
         expect($giveaway->getCopies())->same(10);
         expect($giveaway->getComments())->same(10);

--- a/tests/GetGiveawayTest.php
+++ b/tests/GetGiveawayTest.php
@@ -15,6 +15,7 @@ use Marmozist\SteamGifts\Application\Client;
 use Marmozist\SteamGifts\Application\ClientFactory;
 use Marmozist\SteamGifts\Application\GiveawayProvider\HttpGiveawayProcessor\Factory\CompositeGiveawayProcessorFactory;
 use Marmozist\SteamGifts\Application\GiveawayProvider\HttpGiveawayProvider;
+use Marmozist\SteamGifts\Application\Proxy\LazyUserProxy;
 use Marmozist\SteamGifts\Application\UserProvider\InMemoryUserProvider;
 use Marmozist\SteamGifts\Component\Giveaway\Giveaway;
 use Marmozist\SteamGifts\UseCase\GetUser\Interactor;
@@ -48,7 +49,7 @@ class GetGiveawayTest extends TestCase
         expect($giveaway->getFinishedAt())->equals(new \DateTimeImmutable('2017-06-27T20:00:00.000000+0000'));
         expect($giveaway->getCreatedAt())->equals(new \DateTimeImmutable('2017-06-26T19:13:12.000000+0000'));
         expect($giveaway->getEntries())->same(911);
-        expect($giveaway->getCreator())->equals($client->getUser('Gotman'));
+        expect($giveaway->getCreator())->equals(new LazyUserProxy(new Interactor(new InMemoryUserProvider()), 'Gotman'));
         expect($giveaway->getCost())->same(2);
         expect($giveaway->getCopies())->same(10);
         expect($giveaway->getComments())->same(10);


### PR DESCRIPTION
### What is done?

Added `LazyUserProxy` for user lazy loading. This proxy is used when getting a giveaway.

### How to use?
```php
use Marmozist\SteamGifts\Application\Proxy\LazyUserProxy;
use Marmozist\SteamGifts\UseCase\GetUser;
use Marmozist\SteamGifts\Application\UserProvider\Factory\HttpUserProviderFactory;
use Marmozist\SteamGifts\Application\Utils\Http\HttpClientType;
use Marmozist\SteamGifts\Application\UserProvider\HttpUserProcessor\Factory\CompositeUserProcessorFactory;

$userProvider = HttpUserProviderFactory::createProvider(
    HttpClientType::Curl(), 
    CompositeUserProcessorFactory::createProcessor()
);
$interactor = new GetUser\Interactor($userProvider);

$user = new LazyUserProxy($interactor, 'Gotman');
```