### PR TITLE
Rework http providers

### DIFF
--- a/src/Application/GiveawayProvider/Factory/HttpGiveawayProviderFactory.php
+++ b/src/Application/GiveawayProvider/Factory/HttpGiveawayProviderFactory.php
@@ -7,12 +7,14 @@ namespace Marmozist\SteamGifts\Application\GiveawayProvider\Factory;
 use Buzz\Client as Buzz;
 use Http\Adapter\Guzzle6;
 use Http\Client\Curl;
-use Http\Client\HttpClient;
+use Http\Client\HttpClient as BaseHttpClient;
 use Http\Message\MessageFactory;
 use Http\Message\MessageFactory\DiactorosMessageFactory;
 use Http\Message\MessageFactory\GuzzleMessageFactory;
 use Marmozist\SteamGifts\Application\GiveawayProvider\HttpGiveawayProcessor\GiveawayProcessor;
 use Marmozist\SteamGifts\Application\GiveawayProvider\HttpGiveawayProvider;
+use Marmozist\SteamGifts\Application\HttpClient\HttpClient;
+use Marmozist\SteamGifts\Application\HttpClient\HttpClientParameters;
 use Marmozist\SteamGifts\Application\Utils\Http\HttpClientType;
 
 /**
@@ -22,12 +24,18 @@ use Marmozist\SteamGifts\Application\Utils\Http\HttpClientType;
  */
 class HttpGiveawayProviderFactory
 {
-    public static function createProvider(HttpClientType $type, GiveawayProcessor $userProcessor): HttpGiveawayProvider
+    public static function createProvider(HttpClientType $type, GiveawayProcessor $giveawayProcessor): HttpGiveawayProvider
     {
-        return new HttpGiveawayProvider(static::getClient($type), static::getFactory($type), $userProcessor);
+        $httpClient = new HttpClient(
+            static::getClient($type),
+            static::getFactory($type),
+            HttpClientParameters::createBuilder()->build()
+        );
+
+        return new HttpGiveawayProvider($httpClient, $giveawayProcessor);
     }
 
-    protected static function getClient(HttpClientType $type): HttpClient
+    protected static function getClient(HttpClientType $type): BaseHttpClient
     {
         switch ($type) {
             case HttpClientType::Guzzle():

--- a/src/Application/HttpClient/HttpClient.php
+++ b/src/Application/HttpClient/HttpClient.php
@@ -1,0 +1,46 @@
+<?php declare(strict_types=1);
+
+
+namespace Marmozist\SteamGifts\Application\HttpClient;
+
+
+use Http\Client\HttpClient as BaseHttpClient;
+use Http\Message\RequestFactory;
+use Psr\Http\Client\ClientExceptionInterface;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * @link    http://github.com/marmozist/steam-gifts
+ * @license http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
+ * @author  Andrey Gotmanov <gotman.man@gmail.com>
+ */
+class HttpClient
+{
+    private BaseHttpClient $httpClient;
+    private RequestFactory $requestFactory;
+    private HttpClientParameters $parameters;
+
+    public function __construct(
+        BaseHttpClient $httpClient,
+        RequestFactory $requestFactory,
+        HttpClientParameters $parameters
+    ) {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->parameters = $parameters;
+    }
+
+    /**
+     * @param string $uri
+     * @return ResponseInterface
+     * @throws ClientExceptionInterface
+     */
+    public function get(string $uri): ResponseInterface
+    {
+        $request = $this->requestFactory->createRequest('GET', $this->parameters->getBaseUri() . $uri, [
+            'User-Agent' => $this->parameters->getUserAgent()->getValue()
+        ]);
+
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Application/HttpClient/HttpClientParameters.php
+++ b/src/Application/HttpClient/HttpClientParameters.php
@@ -1,0 +1,37 @@
+<?php declare(strict_types=1);
+
+
+namespace Marmozist\SteamGifts\Application\HttpClient;
+
+
+/**
+ * @link    http://github.com/marmozist/steam-gifts
+ * @license http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
+ * @author  Andrey Gotmanov <gotman.man@gmail.com>
+ */
+class HttpClientParameters
+{
+    private string $baseUri;
+    private UserAgentType $userAgent;
+
+    public function __construct(string $baseUri, UserAgentType $userAgent)
+    {
+        $this->baseUri = $baseUri;
+        $this->userAgent = $userAgent;
+    }
+
+    public static function createBuilder(): HttpClientParametersBuilder
+    {
+        return new HttpClientParametersBuilder();
+    }
+
+    public function getBaseUri(): string
+    {
+        return $this->baseUri;
+    }
+
+    public function getUserAgent(): UserAgentType
+    {
+        return $this->userAgent;
+    }
+}

--- a/src/Application/HttpClient/HttpClientParametersBuilder.php
+++ b/src/Application/HttpClient/HttpClientParametersBuilder.php
@@ -1,0 +1,38 @@
+<?php declare(strict_types=1);
+
+
+namespace Marmozist\SteamGifts\Application\HttpClient;
+
+
+/**
+ * @link    http://github.com/marmozist/steam-gifts
+ * @license http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
+ * @author  Andrey Gotmanov <gotman.man@gmail.com>
+ */
+class HttpClientParametersBuilder
+{
+    private string $baseUri = 'https://www.steamgifts.com';
+    private UserAgentType $userAgent;
+
+    public function build(): HttpClientParameters
+    {
+        return new HttpClientParameters(
+            $this->baseUri,
+            $this->userAgent ?? UserAgentType::ChromeV80Linux()
+        );
+    }
+
+    public function setBaseUri(string $baseUri): HttpClientParametersBuilder
+    {
+        $this->baseUri = $baseUri;
+
+        return $this;
+    }
+
+    public function setUserAgent(UserAgentType $userAgent): HttpClientParametersBuilder
+    {
+        $this->userAgent = $userAgent;
+
+        return $this;
+    }
+}

--- a/src/Application/HttpClient/UserAgentType.php
+++ b/src/Application/HttpClient/UserAgentType.php
@@ -1,0 +1,33 @@
+<?php declare(strict_types=1);
+
+
+namespace Marmozist\SteamGifts\Application\HttpClient;
+
+
+use MyCLabs\Enum\Enum;
+
+/**
+ * @link    http://github.com/marmozist/steam-gifts
+ * @license http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
+ * @author  Andrey Gotmanov <gotman.man@gmail.com>
+ *
+ * @method static self FirefoxV73MacOS10()
+ * @method static self FirefoxV74Linux()
+ * @method static self FirefoxV75WindowsV81()
+ * @method static self FirefoxV73WindowsV10()
+ * @method static self ChromeV79MacOSV10()
+ * @method static self ChromeV80Linux()
+ * @method static self ChromeV79WindowsV81()
+ * @method static self ChromeV80WindowsV10()
+ */
+class UserAgentType extends Enum
+{
+    const FirefoxV73MacOS10 = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.14; rv:73.0) Gecko/20100101 Firefox/73.0';
+    const FirefoxV74Linux = 'Mozilla/5.0 (X11; Linux i686; rv:74.0) Gecko/20100101 Firefox/74.0';
+    const FirefoxV75WindowsV81 = 'Mozilla/5.0 (Windows NT 6.3; WOW64; rv:75.0) Gecko/20100101 Firefox/75.0';
+    const FirefoxV73WindowsV10 = 'Mozilla/5.0 (Windows NT 10.0; WOW64; rv:73.1) Gecko/20100101 Firefox/73.1';
+    const ChromeV79MacOSV10 =   'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.121 Safari/537.36';
+    const ChromeV80Linux = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.149 Safari/537.36';
+    const ChromeV79WindowsV81 = 'Mozilla/5.0 (Windows NT 6.3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.141 Safari/537.36';
+    const ChromeV80WindowsV10 = 'Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.83 Safari/537.36';
+}

--- a/src/Application/UserProvider/Factory/HttpUserProviderFactory.php
+++ b/src/Application/UserProvider/Factory/HttpUserProviderFactory.php
@@ -7,10 +7,12 @@ namespace Marmozist\SteamGifts\Application\UserProvider\Factory;
 use Buzz\Client as Buzz;
 use Http\Adapter\Guzzle6;
 use Http\Client\Curl;
-use Http\Client\HttpClient;
+use Http\Client\HttpClient as BaseHttpClient;
 use Http\Message\MessageFactory;
 use Http\Message\MessageFactory\DiactorosMessageFactory;
 use Http\Message\MessageFactory\GuzzleMessageFactory;
+use Marmozist\SteamGifts\Application\HttpClient\HttpClient;
+use Marmozist\SteamGifts\Application\HttpClient\HttpClientParameters;
 use Marmozist\SteamGifts\Application\UserProvider\HttpUserProcessor\UserProcessor;
 use Marmozist\SteamGifts\Application\UserProvider\HttpUserProvider;
 use Marmozist\SteamGifts\Application\Utils\Http\HttpClientType;
@@ -24,10 +26,16 @@ class HttpUserProviderFactory
 {
     public static function createProvider(HttpClientType $type, UserProcessor $userProcessor): HttpUserProvider
     {
-        return new HttpUserProvider(static::getClient($type), static::getFactory($type), $userProcessor);
+        $httpClient = new HttpClient(
+            static::getClient($type),
+            static::getFactory($type),
+            HttpClientParameters::createBuilder()->build()
+        );
+
+        return new HttpUserProvider($httpClient, $userProcessor);
     }
 
-    protected static function getClient(HttpClientType $type): HttpClient
+    protected static function getClient(HttpClientType $type): BaseHttpClient
     {
         switch ($type) {
             case HttpClientType::Guzzle():

--- a/tests/Application/GiveawayProvider/Factory/HttpGiveawayProviderFactoryTest.php
+++ b/tests/Application/GiveawayProvider/Factory/HttpGiveawayProviderFactoryTest.php
@@ -9,6 +9,9 @@ use Http\Message\MessageFactory\GuzzleMessageFactory;
 use Marmozist\SteamGifts\Application\GiveawayProvider\Factory\HttpGiveawayProviderFactory;
 use Marmozist\SteamGifts\Application\GiveawayProvider\HttpGiveawayProcessor\GiveawayProcessor;
 use Marmozist\SteamGifts\Application\GiveawayProvider\HttpGiveawayProvider;
+use Marmozist\SteamGifts\Application\HttpClient\HttpClient;
+use Marmozist\SteamGifts\Application\HttpClient\HttpClientParameters;
+use Marmozist\SteamGifts\Application\HttpClient\UserAgentType;
 use Marmozist\SteamGifts\Application\Utils\Http\HttpClientType;
 use PHPUnit\Framework\TestCase;
 use Buzz\Client as Buzz;
@@ -40,18 +43,20 @@ class HttpGiveawayProviderFactoryTest extends TestCase
      */
     public function createProviderExamples(): array
     {
+        $parameters = HttpClientParameters::createBuilder()->build();
+
         return [
             [
                 HttpClientType::Guzzle(),
-                new HttpGiveawayProvider(new Guzzle6\Client(), new GuzzleMessageFactory(), $this->prophesize(GiveawayProcessor::class)->reveal()),
+                new HttpGiveawayProvider(new HttpClient(new Guzzle6\Client(), new GuzzleMessageFactory(), $parameters), $this->prophesize(GiveawayProcessor::class)->reveal()),
             ],
             [
                 HttpClientType::Buzz(),
-                new HttpGiveawayProvider(new Buzz\FileGetContents(new DiactorosMessageFactory()), new DiactorosMessageFactory(), $this->prophesize(GiveawayProcessor::class)->reveal()),
+                new HttpGiveawayProvider(new HttpClient(new Buzz\FileGetContents(new DiactorosMessageFactory()), new DiactorosMessageFactory(), $parameters), $this->prophesize(GiveawayProcessor::class)->reveal()),
             ],
             [
                 HttpClientType::Curl(),
-                new HttpGiveawayProvider(new Curl\Client(), new DiactorosMessageFactory(), $this->prophesize(GiveawayProcessor::class)->reveal()),
+                new HttpGiveawayProvider(new HttpClient(new Curl\Client(), new DiactorosMessageFactory(), $parameters), $this->prophesize(GiveawayProcessor::class)->reveal()),
             ],
         ];
     }

--- a/tests/Application/HttpClient/HttpClientParametersBuilderTest.php
+++ b/tests/Application/HttpClient/HttpClientParametersBuilderTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Marmozist\Tests\SteamGifts\Application\HttpClient;
+
+use Marmozist\SteamGifts\Application\HttpClient\HttpClientParameters;
+use Marmozist\SteamGifts\Application\HttpClient\UserAgentType;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @link    http://github.com/marmozist/steam-gifts
+ * @license http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
+ * @author  Andrey Gotmanov <gotman.man@gmail.com>
+ */
+class HttpClientParametersBuilderTest extends TestCase
+{
+    public function testBuild(): void
+    {
+        $builder = HttpClientParameters::createBuilder();
+        $builder
+            ->setUserAgent(UserAgentType::ChromeV80Linux())
+            ->setBaseUri('custom');
+
+        $parameters = $builder->build();
+        expect($parameters)->isInstanceOf(HttpClientParameters::class);
+        expect($parameters->getBaseUri())->same('custom');
+        expect($parameters->getUserAgent())->equals(UserAgentType::ChromeV80Linux());
+    }
+
+    /**
+     * @test
+     */
+    public function buildsWithoutSettersCalling(): void
+    {
+        $parameters = HttpClientParameters::createBuilder()->build();
+        expect($parameters)->isInstanceOf(HttpClientParameters::class);
+        expect($parameters->getBaseUri())->same('https://www.steamgifts.com');
+        expect($parameters->getUserAgent())->equals(UserAgentType::ChromeV80Linux());
+    }
+}

--- a/tests/Application/HttpClient/HttpClientTest.php
+++ b/tests/Application/HttpClient/HttpClientTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Marmozist\Tests\SteamGifts\Application\HttpClient;
+
+use Http\Message\RequestFactory;
+use Marmozist\SteamGifts\Application\HttpClient\HttpClient;
+use Marmozist\SteamGifts\Application\HttpClient\HttpClientParameters;
+use Http\Mock;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Prophecy\ObjectProphecy;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * @link    http://github.com/marmozist/steam-gifts
+ * @license http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
+ * @author  Andrey Gotmanov <gotman.man@gmail.com>
+ */
+class HttpClientTest extends TestCase
+{
+    private Mock\Client $mockClient;
+    private ObjectProphecy $requestFactory;
+    private HttpClient $client;
+
+    protected function setUp(): void
+    {
+        $this->mockClient = new Mock\Client();
+        $this->requestFactory = $this->prophesize(RequestFactory::class);
+        $this->client = new HttpClient($this->mockClient, $this->requestFactory->reveal(), HttpClientParameters::createBuilder()->build());
+    }
+
+    public function testGet(): void
+    {
+        $response = $this->prophesize(ResponseInterface::class);
+        $this->mockClient->addResponse($response->reveal());
+
+        $request = $this->prophesize(RequestInterface::class)->reveal();
+        $this->requestFactory
+            ->createRequest("GET", "https://www.steamgifts.com/target/uri/path", [
+                'User-Agent' => 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.149 Safari/537.36'
+            ])
+            ->shouldBeCalled()
+            ->willReturn($request);
+
+        $this->client->get('/target/uri/path');
+    }
+}

--- a/tests/Application/UserProvider/Factory/HttpUserProviderFactoryTest.php
+++ b/tests/Application/UserProvider/Factory/HttpUserProviderFactoryTest.php
@@ -6,6 +6,9 @@ namespace Marmozist\Tests\SteamGifts\Application\UserProvider\Factory;
 
 use Http\Message\MessageFactory\DiactorosMessageFactory;
 use Http\Message\MessageFactory\GuzzleMessageFactory;
+use Marmozist\SteamGifts\Application\HttpClient\HttpClient;
+use Marmozist\SteamGifts\Application\HttpClient\HttpClientParameters;
+use Marmozist\SteamGifts\Application\HttpClient\UserAgentType;
 use Marmozist\SteamGifts\Application\Utils\Http\HttpClientType;
 use Marmozist\SteamGifts\Application\UserProvider\Factory\HttpUserProviderFactory;
 use Marmozist\SteamGifts\Application\UserProvider\HttpUserProcessor\UserProcessor;
@@ -40,18 +43,20 @@ class HttpUserProviderFactoryTest extends TestCase
      */
     public function createProviderExamples(): array
     {
+        $parameters = HttpClientParameters::createBuilder()->build();
+
         return [
             [
                 HttpClientType::Guzzle(),
-                new HttpUserProvider(new Guzzle6\Client(), new GuzzleMessageFactory(), $this->prophesize(UserProcessor::class)->reveal()),
+                new HttpUserProvider(new HttpClient(new Guzzle6\Client(), new GuzzleMessageFactory(), $parameters), $this->prophesize(UserProcessor::class)->reveal()),
             ],
             [
                 HttpClientType::Buzz(),
-                new HttpUserProvider(new Buzz\FileGetContents(new DiactorosMessageFactory()), new DiactorosMessageFactory(), $this->prophesize(UserProcessor::class)->reveal()),
+                new HttpUserProvider(new HttpClient(new Buzz\FileGetContents(new DiactorosMessageFactory()), new DiactorosMessageFactory(), $parameters), $this->prophesize(UserProcessor::class)->reveal()),
             ],
             [
                 HttpClientType::Curl(),
-                new HttpUserProvider(new Curl\Client(), new DiactorosMessageFactory(), $this->prophesize(UserProcessor::class)->reveal()),
+                new HttpUserProvider(new HttpClient(new Curl\Client(), new DiactorosMessageFactory(), $parameters), $this->prophesize(UserProcessor::class)->reveal()),
             ],
         ];
     }

--- a/tests/Application/UserProvider/HttpUserProviderTest.php
+++ b/tests/Application/UserProvider/HttpUserProviderTest.php
@@ -4,8 +4,7 @@
 namespace Marmozist\Tests\SteamGifts\Application\UserProvider;
 
 
-use Http\Message\RequestFactory;
-use Http\Mock\Client;
+use Marmozist\SteamGifts\Application\HttpClient\HttpClient;
 use Marmozist\SteamGifts\Application\UserProvider\HttpUserProcessor\UserProcessor;
 use Marmozist\SteamGifts\Application\UserProvider\HttpUserProvider;
 use Marmozist\SteamGifts\Component\User\User;
@@ -13,7 +12,6 @@ use Marmozist\SteamGifts\UseCase\GetUser\UserNotFound;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\Prophecy\ObjectProphecy;
-use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamInterface;
 
@@ -24,18 +22,16 @@ use Psr\Http\Message\StreamInterface;
  */
 class HttpUserProviderTest extends TestCase
 {
-    private Client $mockClient;
+    private ObjectProphecy $httpClient;
     private ObjectProphecy $userProcessor;
-    private ObjectProphecy $requestFactory;
     private HttpUserProvider $provider;
 
     protected function setUp(): void
     {
-        $this->mockClient = new Client();
+        $this->httpClient = $this->prophesize(HttpClient::class);
         $this->userProcessor = $this->prophesize(UserProcessor::class);
-        $this->requestFactory = $this->prophesize(RequestFactory::class);
 
-        $this->provider = new HttpUserProvider($this->mockClient, $this->requestFactory->reveal(), $this->userProcessor->reveal());
+        $this->provider = new HttpUserProvider($this->httpClient->reveal(), $this->userProcessor->reveal());
     }
 
     public function testGetUser(): void
@@ -50,20 +46,14 @@ class HttpUserProviderTest extends TestCase
         $response = $this->prophesize(ResponseInterface::class);
         $response->getStatusCode()->shouldBeCalled()->willReturn(200);
         $response->getBody()->shouldBeCalled()->willReturn($stream->reveal());
-
-        $this->mockClient->addResponse($response->reveal());
+        $this->httpClient
+            ->get('/user/' . $username)
+            ->shouldBeCalled()
+            ->willReturn($response);
 
         $this->userProcessor
             ->processUser($content, $builder)
             ->shouldBeCalled();
-
-        $request = $this->prophesize(RequestInterface::class)->reveal();
-        $this->requestFactory
-            ->createRequest("GET", "https://www.steamgifts.com/user/$username", [
-                'User-Agent' => 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.149 Safari/537.36'
-            ])
-            ->shouldBeCalled()
-            ->willReturn($request);
 
         expect($this->provider->getUser($username))->equals($builder->build());
     }
@@ -81,19 +71,14 @@ class HttpUserProviderTest extends TestCase
 
         $response = $this->prophesize(ResponseInterface::class);
         $response->getStatusCode()->shouldBeCalled()->willReturn(404);
-        $this->mockClient->addResponse($response->reveal());
+        $this->httpClient
+            ->get('/user/' . $username)
+            ->shouldBeCalled()
+            ->willReturn($response);
 
         $this->userProcessor
             ->processUser(Argument::any(), $builder)
             ->shouldNotBeCalled();
-
-        $request = $this->prophesize(RequestInterface::class)->reveal();
-        $this->requestFactory
-            ->createRequest("GET", "https://www.steamgifts.com/user/$username", [
-                'User-Agent' => 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.149 Safari/537.36'
-            ])
-            ->shouldBeCalled()
-            ->willReturn($request);
 
         expect($this->provider->getUser($username))->equals($builder->build());
     }
@@ -104,26 +89,23 @@ class HttpUserProviderTest extends TestCase
     public function throwsWhenUnknownError(): void
     {
         $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('Unknown http error. Code: 500');
+        $this->expectExceptionMessage('Error 123');
+        $this->expectExceptionCode(500);
 
         $username = 'Username';
         $builder = User::createBuilder($username);
 
         $response = $this->prophesize(ResponseInterface::class);
         $response->getStatusCode()->shouldBeCalled()->willReturn(500);
-        $this->mockClient->addResponse($response->reveal());
+        $response->getBody()->shouldBeCalled()->willReturn('Error 123');
+        $this->httpClient
+            ->get('/user/' . $username)
+            ->shouldBeCalled()
+            ->willReturn($response);
 
         $this->userProcessor
             ->processUser(Argument::any(), $builder)
             ->shouldNotBeCalled();
-
-        $request = $this->prophesize(RequestInterface::class)->reveal();
-        $this->requestFactory
-            ->createRequest("GET", "https://www.steamgifts.com/user/$username", [
-                'User-Agent' => 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.149 Safari/537.36'
-            ])
-            ->shouldBeCalled()
-            ->willReturn($request);
 
         expect($this->provider->getUser($username))->equals($builder->build());
     }

--- a/tests/GetGiveawayListTest.php
+++ b/tests/GetGiveawayListTest.php
@@ -4,22 +4,15 @@
 namespace Marmozist\Tests\SteamGifts;
 
 
-use Http\Client\Common\PluginClient;
 use Http\Client\HttpClient;
-use Http\Client\Plugin\Vcr\NamingStrategy\PathNamingStrategy;
-use Http\Client\Plugin\Vcr\Recorder\FilesystemRecorder;
-use Http\Client\Plugin\Vcr\RecordPlugin;
-use Http\Client\Plugin\Vcr\ReplayPlugin;
 use Http\Message\MessageFactory\DiactorosMessageFactory;
-use Marmozist\SteamGifts\Application\Client;
-use Marmozist\SteamGifts\Application\ClientFactory;
-use Marmozist\SteamGifts\Application\GiveawayProvider\HttpGiveawayProcessor\Factory\CompositeGiveawayProcessorFactory;
-use Marmozist\SteamGifts\Application\GiveawayProvider\HttpGiveawayProvider;
 use Marmozist\SteamGifts\Application\Proxy\LazyUserProxy;
 use Marmozist\SteamGifts\Application\UserProvider\InMemoryUserProvider;
 use Marmozist\SteamGifts\Component\Giveaway\Giveaway;
+use Marmozist\SteamGifts\Component\User\UserRole;
 use Marmozist\SteamGifts\UseCase\GetGiveawayList\GiveawayList;
 use Marmozist\SteamGifts\UseCase\GetUser\Interactor;
+use Marmozist\Tests\SteamGifts\Helper\ClientHelper;
 use PHPUnit\Framework\TestCase;
 use Buzz\Client as Buzz;
 use Http\Adapter\Guzzle6;
@@ -35,11 +28,12 @@ use Http\Client\Curl;
 class GetGiveawayListTest extends TestCase
 {
     /**
-     * @param Client $client
+     * @param HttpClient $httpClient
      * @dataProvider httpClientExamples
      */
-    public function testGetGiveawayList(Client $client): void
+    public function testGetGiveawayList(HttpClient $httpClient): void
     {
+        $client = ClientHelper::createReplayClient($httpClient);
         $userList = $client->getGiveawayList(['9KfZs', '9KfKs']);
         expect($userList)->isInstanceOf(GiveawayList::class);
         expect($userList)->count(1);
@@ -55,7 +49,8 @@ class GetGiveawayListTest extends TestCase
         expect($giveaway->getFinishedAt())->equals(new \DateTimeImmutable('2017-06-27T20:00:00.000000+0000'));
         expect($giveaway->getCreatedAt())->equals(new \DateTimeImmutable('2017-06-26T19:13:12.000000+0000'));
         expect($giveaway->getEntries())->same(911);
-        expect($giveaway->getCreator())->equals(new LazyUserProxy(new Interactor(new InMemoryUserProvider()), 'Gotman'));
+        expect($giveaway->getCreator()->getName())->same('Gotman');
+        expect($giveaway->getCreator()->getRole())->equals(UserRole::Member());
         expect($giveaway->getCost())->same(2);
         expect($giveaway->getCopies())->same(10);
         expect($giveaway->getComments())->same(10);
@@ -67,37 +62,9 @@ class GetGiveawayListTest extends TestCase
     public function httpClientExamples(): array
     {
         return [
-            [$this->createHttpClient(new Guzzle6\Client())],
-            [$this->createHttpClient(new Curl\Client())],
-            [$this->createHttpClient(new Buzz\FileGetContents(new DiactorosMessageFactory()))],
+            [new Guzzle6\Client()],
+            [new Curl\Client()],
+            [new Buzz\FileGetContents(new DiactorosMessageFactory())],
         ];
-    }
-
-    private function createHttpClient(HttpClient $client): Client
-    {
-        $userProvider = new InMemoryUserProvider();
-
-        return ClientFactory::createClient($userProvider, new HttpGiveawayProvider(
-            $this->createPluginClient($client),
-            new DiactorosMessageFactory(),
-            CompositeGiveawayProcessorFactory::createProcessor(new Interactor($userProvider)),
-        ));
-    }
-
-    private function createPluginClient(HttpClient $client): PluginClient
-    {
-        $namingStrategy = new PathNamingStrategy();
-        $recorder = new FilesystemRecorder(__DIR__ . '/Fixtures/http');
-
-        $record = new RecordPlugin($namingStrategy, $recorder);
-        $replay = new ReplayPlugin($namingStrategy, $recorder);
-
-        return new PluginClient(
-            $client,
-            [
-                //$record,
-                $replay
-            ]
-        );
     }
 }

--- a/tests/Helper/ClientHelper.php
+++ b/tests/Helper/ClientHelper.php
@@ -1,0 +1,69 @@
+<?php declare(strict_types=1);
+
+
+namespace Marmozist\Tests\SteamGifts\Helper;
+
+
+use Http\Client\Common\Plugin;
+use Http\Client\Common\PluginClient;
+use Http\Client\HttpClient as BaseHttpClient;
+use Http\Client\Plugin\Vcr\NamingStrategy\PathNamingStrategy;
+use Http\Client\Plugin\Vcr\Recorder\FilesystemRecorder;
+use Http\Client\Plugin\Vcr\RecordPlugin;
+use Http\Client\Plugin\Vcr\ReplayPlugin;
+use Http\Message\MessageFactory\DiactorosMessageFactory;
+use Marmozist\SteamGifts\Application\Client;
+use Marmozist\SteamGifts\Application\ClientFactory;
+use Marmozist\SteamGifts\Application\GiveawayProvider\HttpGiveawayProcessor\Factory\CompositeGiveawayProcessorFactory;
+use Marmozist\SteamGifts\Application\GiveawayProvider\HttpGiveawayProvider;
+use Marmozist\SteamGifts\Application\HttpClient\HttpClient;
+use Marmozist\SteamGifts\Application\HttpClient\HttpClientParameters;
+use Marmozist\SteamGifts\Application\UserProvider\HttpUserProcessor\Factory\CompositeUserProcessorFactory;
+use Marmozist\SteamGifts\Application\UserProvider\HttpUserProvider;
+use Marmozist\SteamGifts\UseCase\GetUser\Interactor;
+
+/**
+ * @link    http://github.com/marmozist/steam-gifts
+ * @license http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
+ * @author  Andrey Gotmanov <gotman.man@gmail.com>
+ */
+class ClientHelper
+{
+    public static function createRecordClient(BaseHttpClient $client): Client
+    {
+        $namingStrategy = new PathNamingStrategy();
+        $recorder = new FilesystemRecorder(__DIR__ . '/Fixtures/http');
+        $record = new RecordPlugin($namingStrategy, $recorder);
+
+        return self::createClient($client, $record);
+    }
+
+    public static function createReplayClient(BaseHttpClient $client): Client
+    {
+        $namingStrategy = new PathNamingStrategy();
+        $recorder = new FilesystemRecorder(__DIR__ . '/../Fixtures/http');
+        $replay = new ReplayPlugin($namingStrategy, $recorder);
+
+        return self::createClient($client, $replay);
+    }
+
+    private static function createClient(BaseHttpClient $client, Plugin $plugin): Client
+    {
+        $httpClient = new HttpClient(
+            new PluginClient($client, [$plugin]),
+            new DiactorosMessageFactory(), HttpClientParameters::createBuilder()->build()
+        );
+
+        $userProvider = new HttpUserProvider(
+            $httpClient,
+            CompositeUserProcessorFactory::createProcessor(),
+        );
+
+        $giveawayProvider = new HttpGiveawayProvider(
+            $httpClient,
+            CompositeGiveawayProcessorFactory::createProcessor(new Interactor($userProvider))
+        );
+
+        return ClientFactory::createClient($userProvider, $giveawayProvider);
+    }
+}


### PR DESCRIPTION
### What is motivation?

+ No duplicate code in http providers;
+ Ability to set custom http request parameters (base-uri, user-agent, etc.);
+ Following the Single Responsibility Principle.

### What is done?

+ Class `HttpClient` has `Http\Client\HttpClient`/`RequestFactory`/`HttpClientParameters` dependencies;
+ Class `HttpClientParameters` has a `baseUri` property of `string` type and `userAgent` property of `UserAgentType` enum type. The class has public getters methods and public static `createBuilder` method;
+ Class `HttpClientParametersBuilder` has setters methods for `baseUri`/`userAgent` properties and `build`  method (returns `HttpClientParameters` new instance);
+ Class `UserAgentType` is enum. The class contains a small set of user-agents. Also it is possible to expand;
+ Classes `HttpGiveawayProvider`/`HttpUserProvider` removed `RequestFactory` dependency and `Http\Client\HttpClient` was replaced by `Marmozist\SteamGifts\Application\HttpClient\HttpClient`.

### How to use?
```php
use Marmozist\SteamGifts\Application\HttpClient\HttpClient;
use Http\Client\HttpClient as BaseHttpClient;
use Http\Adapter\Guzzle6;

$parameters = HttpClientParameters::createBuilder()
    ->setUserAgent(UserAgentType::ChromeV80Linux())
    ->setBaseUri('https://www.steamgifts.com')
    ->build();
$client = new HttpClient((new Guzzle6\Client(), new GuzzleMessageFactory(), $parameters);
$response = $client->get('/user/Gotman');
$response2 = $client->get('/giveaway/I3mBK/flight-simulator-vr');
```
